### PR TITLE
 Added support for each loop, and sub-transform block and pluck

### DIFF
--- a/src/controllers/process_controller.ts
+++ b/src/controllers/process_controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "../types.ts";
-import transform from "../core/transform.ts";
+import {transform} from "../core/transform.ts";
 
 const ProcessController: Controller = async (_urlData, request) => {
   try {

--- a/src/core/custom_transforms.ts
+++ b/src/core/custom_transforms.ts
@@ -1,7 +1,9 @@
 import mozjexl from "npm:mozjexl";
+import { transform, _isSubTransformBlock, _isTemporaryField, _updateDerivedState } from "./transform.ts";
+import { DataObject } from "../types.ts";
 
 mozjexl.addTransform("upper", (val: Array<string> | string) => {
-    if(typeof val === "string") return val.toUpperCase();
+  if (typeof val === "string") return val.toUpperCase();
   const result: Array<string> = [];
   val.forEach((record) => {
     if (typeof record === "string") {
@@ -13,4 +15,43 @@ mozjexl.addTransform("upper", (val: Array<string> | string) => {
   return result;
 });
 
+mozjexl.addTransform(
+  "forEach",
+  async (
+    val: Array<any>,
+    context: Record<string, any>,
+    transforms: Record<string, any>[],
+  ) => {
+    if (context === null) context = {};
+    const forEachResult: Array<any> = [];
+    for (let idx = 0; idx < val.length; idx++) {
+      const dataObject: DataObject = {
+        input: { ...context, item: val[idx], _idx: idx },
+        transforms: transforms,
+        settings: {
+          merge_method: "transforms_only",
+        },
+      };
+      const result = await transform(dataObject);
+      Object.keys(context).forEach((field) => {
+        if (result[field]) context[field] = result[field];
+      });
+      forEachResult.push(result);
+    }
+    return forEachResult;
+  },
+);
+
+mozjexl.addTransform("pluck", (val: Array<any>, properties: Array<String>) => {
+  const result = [];
+  const justOneProperty: boolean = properties.length === 1 ? true : false;
+  for (let idx = 0; idx < val.length; idx++) {
+    const objectAtIdx: Record<string, any> = {};
+    properties.forEach((property: any) => {
+      objectAtIdx[property] = val[idx][property];
+    });
+    result.push(justOneProperty ? Object.values(objectAtIdx)[0] : objectAtIdx);
+  }
+  return result;
+});
 export default mozjexl;

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -88,7 +88,7 @@ export const transform = async (
           dataObjectClone.isSubTransformation = false;
         } else {
           let result = await mozjexl.eval(expression, { input, derived });
-          if (result === undefined) {
+          if (result === undefined || result === null) {
             result = {
               "error-102": `The transform ${expression} uses variables not available in the context`,
             };


### PR DESCRIPTION
- Implemented #11 in this pull request.
- i.e. Added support for each loop, and sub-transform block where you can define what logic needs to be executed for each.
- Also added `pluck`, to essentially pluck out desired objects from each item in a list, to be used alongside for each loop.